### PR TITLE
Use relative links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Complete set up of backend for Xfers Connect Flow, users' backend needs to be ab
 - send otp
 
 ### SDK - Android
-Please refer to our Android SDK Getting Started Guide here by going to Android folder or click on the link [here](https://github.com/Xfers/xfers-sdk/tree/master/Android).
+Please refer to our Android SDK Getting Started Guide here by going to [Android folder](./Android).
 
 ### SDK - Web
-Please refer to our Web SDK Getting Started Guide here by going to JavaScript folder or click on the link [here](https://github.com/Xfers/xfers-sdk/tree/master/JavaScript).
+Please refer to our Web SDK Getting Started Guide here by going to [JavaScript folder](./JavaScript).
 
 ## Contributing to our SDK
 Please refer to our [SDK development notes here](https://github.com/Xfers/xfers-sdk/wiki)


### PR DESCRIPTION
### Issue
Clicking on links in the root README will always bring the user to the page in the master branch. This is not always desired especially when we start properly versioning

### Solution
Instead of hard linking to the other READMEs, it is a better idea to use relative links since it will respect the branch that the user is looking at